### PR TITLE
Implement content-scanning interface for wscan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming"]
 license = "MIT"
 
 [dependencies]
-webscan = "0.1.0"
+webscan = {git = "https://github.com/sempervictus/webscan", branch = "feature/content_byte_matching"}
 clap = "2.33"
 tokio = { version = "0.2", features = ["full"] }
 regex = "1"
@@ -19,3 +19,13 @@ chrono = "0.4"
 crossterm = "0.19"
 sudo = "0.6"
 dns-lookup = "1.0"
+## Static build
+# Add openssl-sys as a direct dependency so it can be cross compiled to
+# x86_64-unknown-linux-musl using the "vendored" feature below
+openssl-sys = "*"
+
+[features]
+# Force openssl-sys to staticly link in the openssl library.
+# Necessary when cross compiling to x86_64-unknown-linux-musl.
+vendored = ["openssl-sys/vendored"]
+

--- a/src/util/option.rs
+++ b/src/util/option.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 pub struct UriOption{
     pub base_uri: String,
     pub use_wordlist: bool,
+    pub use_content: bool,
     pub wordlist_path: String,
+    pub content_path: String,
     pub request_method: String,
     pub timeout: Duration,
     pub save_path: String,
@@ -23,7 +25,9 @@ impl UriOption {
         let uri_option = UriOption {
             base_uri: String::new(),
             use_wordlist: false,
+            use_content: false,
             wordlist_path: String::new(),
+            content_path: String::new(),
             request_method: String::new(),
             timeout: Duration::from_millis(30000),
             save_path: String::new(),
@@ -41,6 +45,12 @@ impl UriOption {
         if !file_path.is_empty() {
             self.use_wordlist = true;
             self.wordlist_path = file_path;   
+        }
+    }
+    pub fn set_content_path(&mut self, content_path: String){
+        if !content_path.is_empty() {
+            self.use_content = true;
+            self.content_path = content_path;
         }
     }
     pub fn set_request_method(&mut self, method_name: String){


### PR DESCRIPTION
Expose the webscan library's feature for content matching to the
CLI application. Please note that using the -c flag also requires
an HTTP method other than HEAD (usually GET suffices).

This is the front-end for https://github.com/shellrow/webscan/pull/1